### PR TITLE
#9 `Shape` API refactoring

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,5 +1,5 @@
 use crate::color::{Color, FillRule, FillStyle};
-use crate::geometry::{intersect_line_with_grid, GridPoint, Point, Primitive, Shape};
+use crate::geometry::{intersect_line_with_grid, GridPoint, Path, PathOps, Point};
 use std::vec::Vec;
 
 #[derive(Debug, Clone)]
@@ -124,11 +124,33 @@ impl Canvas {
         });
     }
 
-    pub fn draw_shape(&mut self, shape: Shape, _fill_style: FillStyle, _fill_rule: FillRule) {
-        for primitive in shape.iter() {
-            match primitive {
-                Primitive::Line { start, end } => {
-                    self.draw_line(start, end);
+    pub fn draw_shape(&mut self, path: Path, _fill_style: FillStyle, _fill_rule: FillRule) {
+        let mut currently_at = Point {
+            x: 0.0_f64,
+            y: 0.0_f64,
+        };
+
+        for op in path.iter() {
+            match op {
+                PathOps::MoveTo { x, y } => {
+                    currently_at.x = *x;
+                    currently_at.y = *y;
+                }
+                PathOps::MoveToRel { x, y } => {
+                    currently_at.x += *x;
+                    currently_at.y += *y;
+                }
+                PathOps::LineTo { x, y } => {
+                    self.draw_line(&currently_at, &Point { x: *x, y: *y });
+                }
+                PathOps::LineToRel { x, y } => {
+                    self.draw_line(
+                        &currently_at,
+                        &Point {
+                            x: currently_at.x + *x,
+                            y: currently_at.y + *y,
+                        },
+                    );
                 }
             }
         }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -60,11 +60,14 @@ impl std::fmt::Display for GridPoint {
     }
 }
 
-pub enum Primitive {
-    Line { start: Point, end: Point },
+pub enum PathOps {
+    MoveTo { x: f64, y: f64 },
+    MoveToRel { x: f64, y: f64 },
+    LineTo { x: f64, y: f64 },
+    LineToRel { x: f64, y: f64 },
 }
 
-pub type Shape = Vec<Primitive>;
+pub type Path = Vec<PathOps>;
 
 ///
 /// Returns the starting and ending coordinates between which we need to iterate, so that

--- a/tests/line_test.rs
+++ b/tests/line_test.rs
@@ -3,7 +3,7 @@
 use verg::{
     canvas::{Canvas, CanvasDescription},
     color::{Color, FillRule, FillStyle},
-    geometry::{Point, Primitive},
+    geometry::PathOps,
 };
 
 #[test]
@@ -24,16 +24,16 @@ fn line_test() {
     });
 
     canvas.draw_shape(
-        vec![Primitive::Line {
-            start: Point {
+        vec![
+            PathOps::MoveTo {
                 x: 120.0_f64,
                 y: 120.0_f64,
             },
-            end: Point {
+            PathOps::LineTo {
                 x: 360.0_f64,
                 y: 360.0_f64,
             },
-        }],
+        ],
         FillStyle::Plain(Color {
             r: 1.0_f64,
             ..Default::default()
@@ -42,16 +42,16 @@ fn line_test() {
     );
 
     canvas.draw_shape(
-        vec![Primitive::Line {
-            start: Point {
+        vec![
+            PathOps::MoveTo {
                 x: 380.0_f64,
                 y: 80.0_f64,
             },
-            end: Point {
+            PathOps::LineTo {
                 x: 200.0_f64,
                 y: 60.0_f64,
             },
-        }],
+        ],
         FillStyle::Plain(Color {
             r: 1.0_f64,
             ..Default::default()
@@ -60,16 +60,16 @@ fn line_test() {
     );
 
     canvas.draw_shape(
-        vec![Primitive::Line {
-            start: Point {
+        vec![
+            PathOps::MoveTo {
                 x: 60.0_f64,
                 y: 20.0_f64,
             },
-            end: Point {
+            PathOps::LineTo {
                 x: 60.0_f64,
                 y: 300.0_f64,
             },
-        }],
+        ],
         FillStyle::Plain(Color {
             r: 1.0_f64,
             ..Default::default()
@@ -78,16 +78,16 @@ fn line_test() {
     );
 
     canvas.draw_shape(
-        vec![Primitive::Line {
-            start: Point {
+        vec![
+            PathOps::MoveTo {
                 x: 60.0_f64,
                 y: 350.0_f64,
             },
-            end: Point {
+            PathOps::LineTo {
                 x: 360.0_f64,
                 y: 350.0_f64,
             },
-        }],
+        ],
         FillStyle::Plain(Color {
             r: 1.0_f64,
             ..Default::default()


### PR DESCRIPTION
Instead of having the path described as a `Vec` of `Primitive`s, we now have the path described as a `Vec` of `PathOps`, which are path operations like `MoveTo`/`LineTo`/etc., which is the conventional way of describing paths.