### PR TITLE
#24 Add support for custom alpha blending

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,6 +1,6 @@
 use crate::color::{Color, FillRule, FillStyle};
 use crate::geometry::Path;
-use crate::renderer::{fill_path, render_path, NUM_CHANNELS};
+use crate::renderer::{blend_func, fill_path, render_path, BlendFunc, NUM_CHANNELS};
 use std::vec::Vec;
 
 #[derive(Debug, Clone, Copy)]
@@ -28,11 +28,11 @@ impl Default for CanvasDescription {
     }
 }
 
-#[derive(Debug)]
 pub struct Canvas {
     buffer: Vec<f64>,
     accumulation_buffer: Vec<AccumulationCell>,
     pub desc: CanvasDescription,
+    blend: BlendFunc,
 }
 
 impl Canvas {
@@ -57,7 +57,12 @@ impl Canvas {
                 desc.width * desc.height
             ],
             desc,
+            blend: blend_func::source_over,
         }
+    }
+
+    pub fn set_blending_function(&mut self, f: BlendFunc) {
+        self.blend = f;
     }
 
     pub fn to_u8(&self) -> Vec<u8> {
@@ -82,6 +87,7 @@ impl Canvas {
             fill_style,
             fill_rule,
             &bounds,
+            self.blend,
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod canvas;
 pub mod color;
 pub mod geometry;
-mod renderer;
+pub mod renderer;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -12,7 +12,7 @@ use crate::{
 pub type BlendFunc = fn(&Color, &Color) -> Color;
 
 pub mod blend_func {
-    use crate::renderer::Color;
+    use crate::{color::clamp, renderer::Color};
 
     pub fn source_over(src: &Color, dest: &Color) -> Color {
         Color {
@@ -20,6 +20,114 @@ pub mod blend_func {
             g: src.g * src.a + dest.g * dest.a * (1.0 - src.a),
             b: src.b * src.a + dest.b * dest.a * (1.0 - src.a),
             a: src.a + dest.a * (1.0 - src.a),
+        }
+    }
+
+    pub fn destination_over(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: src.r * src.a * (1.0 - dest.a) + dest.r * dest.a,
+            g: src.g * src.a * (1.0 - dest.a) + dest.g * dest.a,
+            b: src.b * src.a * (1.0 - dest.a) + dest.b * dest.a,
+            a: src.a * (1.0 - dest.a) + dest.a,
+        }
+    }
+
+    pub fn source_out(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: src.r * src.a * (1.0 - dest.a),
+            g: src.g * src.a * (1.0 - dest.a),
+            b: src.b * src.a * (1.0 - dest.a),
+            a: src.a * (1.0 - dest.a),
+        }
+    }
+
+    pub fn destination_out(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: dest.r * dest.a * (1.0 - src.a),
+            g: dest.g * dest.a * (1.0 - src.a),
+            b: dest.b * dest.a * (1.0 - src.a),
+            a: dest.a * (1.0 - src.a),
+        }
+    }
+
+    pub fn source_in(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: src.r * src.a * dest.a,
+            g: src.g * src.a * dest.a,
+            b: src.b * src.a * dest.a,
+            a: src.a * dest.a,
+        }
+    }
+
+    pub fn destination_in(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: dest.r * dest.a * src.a,
+            g: dest.g * dest.a * src.a,
+            b: dest.b * dest.a * src.a,
+            a: dest.a * src.a,
+        }
+    }
+
+    pub fn source_atop(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: src.r * src.a * dest.a + dest.r * dest.a * (1.0 - src.a),
+            g: src.g * src.a * dest.a + dest.g * dest.a * (1.0 - src.a),
+            b: src.b * src.a * dest.a + dest.b * dest.a * (1.0 - src.a),
+            a: src.a * dest.a + dest.a * (1.0 - src.a),
+        }
+    }
+
+    pub fn destination_atop(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: src.r * src.a * (1.0 - dest.a) + dest.r * dest.a * src.a,
+            g: src.g * src.a * (1.0 - dest.a) + dest.g * dest.a * src.a,
+            b: src.b * src.a * (1.0 - dest.a) + dest.b * dest.a * src.a,
+            a: src.a * (1.0 - dest.a) + dest.a * src.a,
+        }
+    }
+
+    pub fn xor(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: src.r * src.a * (1.0 - dest.a) + dest.r * dest.a * (1.0 - src.a),
+            g: src.g * src.a * (1.0 - dest.a) + dest.g * dest.a * (1.0 - src.a),
+            b: src.b * src.a * (1.0 - dest.a) + dest.b * dest.a * (1.0 - src.a),
+            a: src.a * (1.0 - dest.a) + dest.a * (1.0 - src.a),
+        }
+    }
+
+    pub fn clear(_src: &Color, _dest: &Color) -> Color {
+        Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0.0,
+        }
+    }
+
+    pub fn source(src: &Color, _dest: &Color) -> Color {
+        Color {
+            r: src.r,
+            g: src.g,
+            b: src.b,
+            a: src.a,
+        }
+    }
+
+    pub fn destination(_src: &Color, dest: &Color) -> Color {
+        Color {
+            r: dest.r,
+            g: dest.g,
+            b: dest.b,
+            a: dest.a,
+        }
+    }
+
+    pub fn additive(src: &Color, dest: &Color) -> Color {
+        Color {
+            r: clamp(src.r * src.a + dest.r * dest.a, 0.0, 1.0),
+            g: clamp(src.g * src.a + dest.g * dest.a, 0.0, 1.0),
+            b: clamp(src.b * src.a + dest.b * dest.a, 0.0, 1.0),
+            a: clamp(src.a + dest.a, 0.0, 1.0),
         }
     }
 }
@@ -288,7 +396,7 @@ pub fn fill_path(
     bounds: &BoundingBox,
     blend: BlendFunc,
 ) {
-    for y in bounds.min_y..=bounds.max_y {
+    for y in bounds.min_y..bounds.max_y {
         let mut acc = 0.0_f32;
         let mut filling = -1.0_f32;
         let mut prev_cell = AccumulationCell { area: 0.0, id: 0 };

--- a/tests/alpha_blending_test.rs
+++ b/tests/alpha_blending_test.rs
@@ -1,0 +1,347 @@
+// This tests the Porter-Duff blending operators.
+
+use crate::common::default_blending;
+use verg::{
+    canvas::{Canvas, CanvasDescription},
+    color::{Color, FillRule, FillStyle},
+    geometry::PathOps,
+    renderer::blend_func,
+};
+
+mod common;
+
+const WIDTH: usize = 1400;
+const HEIGHT: usize = 1020;
+
+fn canvas_description() -> CanvasDescription {
+    CanvasDescription {
+        width: WIDTH,
+        height: HEIGHT,
+        background_color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0.0,
+        },
+        ..Default::default()
+    }
+}
+
+const DESTINATION_TRIANGLES: [[PathOps; 4]; 12] = [
+    [
+        PathOps::MoveTo { x: 0.0, y: 20.0 },
+        PathOps::LineTo { x: 200.0, y: 20.0 },
+        PathOps::LineTo { x: 100.0, y: 220.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 400.0, y: 20.0 },
+        PathOps::LineTo { x: 600.0, y: 20.0 },
+        PathOps::LineTo { x: 500.0, y: 220.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 0.0, y: 420.0 },
+        PathOps::LineTo { x: 200.0, y: 420.0 },
+        PathOps::LineTo { x: 100.0, y: 620.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 400.0, y: 420.0 },
+        PathOps::LineTo { x: 600.0, y: 420.0 },
+        PathOps::LineTo { x: 500.0, y: 620.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 0.0, y: 820.0 },
+        PathOps::LineTo { x: 200.0, y: 820.0 },
+        PathOps::LineTo {
+            x: 100.0,
+            y: 1020.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 400.0, y: 820.0 },
+        PathOps::LineTo { x: 600.0, y: 820.0 },
+        PathOps::LineTo {
+            x: 500.0,
+            y: 1020.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 800.0, y: 20.0 },
+        PathOps::LineTo { x: 1000.0, y: 20.0 },
+        PathOps::LineTo { x: 900.0, y: 220.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 1200.0, y: 20.0 },
+        PathOps::LineTo { x: 1400.0, y: 20.0 },
+        PathOps::LineTo {
+            x: 1300.0,
+            y: 220.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 800.0, y: 420.0 },
+        PathOps::LineTo {
+            x: 1000.0,
+            y: 420.0,
+        },
+        PathOps::LineTo { x: 900.0, y: 620.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 1200.0,
+            y: 420.0,
+        },
+        PathOps::LineTo {
+            x: 1400.0,
+            y: 420.0,
+        },
+        PathOps::LineTo {
+            x: 1300.0,
+            y: 620.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 800.0, y: 820.0 },
+        PathOps::LineTo {
+            x: 1000.0,
+            y: 820.0,
+        },
+        PathOps::LineTo {
+            x: 900.0,
+            y: 1020.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 1200.0,
+            y: 820.0,
+        },
+        PathOps::LineTo {
+            x: 1400.0,
+            y: 820.0,
+        },
+        PathOps::LineTo {
+            x: 1300.0,
+            y: 1020.0,
+        },
+        PathOps::Close,
+    ],
+];
+
+const SOURCE_TRIANGLES: [[PathOps; 4]; 12] = [
+    [
+        PathOps::MoveTo { x: 0.0, y: 200.0 },
+        PathOps::LineTo { x: 100.0, y: 0.0 },
+        PathOps::LineTo { x: 200.0, y: 200.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 400.0, y: 200.0 },
+        PathOps::LineTo { x: 500.0, y: 0.0 },
+        PathOps::LineTo { x: 600.0, y: 200.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 0.0, y: 600.0 },
+        PathOps::LineTo { x: 100.0, y: 400.0 },
+        PathOps::LineTo { x: 200.0, y: 600.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 400.0, y: 600.0 },
+        PathOps::LineTo { x: 500.0, y: 400.0 },
+        PathOps::LineTo { x: 600.0, y: 600.0 },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 0.0, y: 1000.0 },
+        PathOps::LineTo { x: 100.0, y: 800.0 },
+        PathOps::LineTo {
+            x: 200.0,
+            y: 1000.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 400.0,
+            y: 1000.0,
+        },
+        PathOps::LineTo { x: 500.0, y: 800.0 },
+        PathOps::LineTo {
+            x: 600.0,
+            y: 1000.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 800.0, y: 200.0 },
+        PathOps::LineTo { x: 900.0, y: 0.0 },
+        PathOps::LineTo {
+            x: 1000.0,
+            y: 200.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 1200.0,
+            y: 200.0,
+        },
+        PathOps::LineTo { x: 1300.0, y: 0.0 },
+        PathOps::LineTo {
+            x: 1400.0,
+            y: 200.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo { x: 800.0, y: 600.0 },
+        PathOps::LineTo { x: 900.0, y: 400.0 },
+        PathOps::LineTo {
+            x: 1000.0,
+            y: 600.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 1200.0,
+            y: 600.0,
+        },
+        PathOps::LineTo {
+            x: 1300.0,
+            y: 400.0,
+        },
+        PathOps::LineTo {
+            x: 1400.0,
+            y: 600.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 800.0,
+            y: 1000.0,
+        },
+        PathOps::LineTo { x: 900.0, y: 800.0 },
+        PathOps::LineTo {
+            x: 1000.0,
+            y: 1000.0,
+        },
+        PathOps::Close,
+    ],
+    [
+        PathOps::MoveTo {
+            x: 1200.0,
+            y: 1000.0,
+        },
+        PathOps::LineTo {
+            x: 1300.0,
+            y: 800.0,
+        },
+        PathOps::LineTo {
+            x: 1400.0,
+            y: 1000.0,
+        },
+        PathOps::Close,
+    ],
+];
+
+static FILL_SOURCE: FillStyle = FillStyle::Plain(Color::coral());
+static FILL_DESTINATION: FillStyle = FillStyle::Plain(Color::dark_slate_blue());
+
+const FILL_RULE: FillRule = FillRule::NonZero;
+
+#[allow(dead_code)]
+fn destination_over(src: &Color, dest: &Color) -> Color {
+    blend_func::destination_over(src, dest)
+}
+
+#[allow(dead_code)]
+fn source_out(src: &Color, dest: &Color) -> Color {
+    blend_func::source_out(src, dest)
+}
+
+#[allow(dead_code)]
+fn destination_out(src: &Color, dest: &Color) -> Color {
+    blend_func::destination_out(src, dest)
+}
+
+#[allow(dead_code)]
+fn source_in(src: &Color, dest: &Color) -> Color {
+    blend_func::source_in(src, dest)
+}
+
+#[allow(dead_code)]
+fn destination_in(src: &Color, dest: &Color) -> Color {
+    blend_func::destination_in(src, dest)
+}
+
+#[allow(dead_code)]
+fn source_atop(src: &Color, dest: &Color) -> Color {
+    blend_func::source_atop(src, dest)
+}
+
+#[allow(dead_code)]
+fn destination_atop(src: &Color, dest: &Color) -> Color {
+    blend_func::destination_atop(src, dest)
+}
+
+#[allow(dead_code)]
+fn xor(src: &Color, dest: &Color) -> Color {
+    blend_func::xor(src, dest)
+}
+
+#[allow(dead_code)]
+fn source(src: &Color, dest: &Color) -> Color {
+    blend_func::source(src, dest)
+}
+
+#[allow(dead_code)]
+fn destination(src: &Color, dest: &Color) -> Color {
+    blend_func::destination(src, dest)
+}
+
+#[allow(dead_code)]
+fn additive(src: &Color, dest: &Color) -> Color {
+    blend_func::additive(src, dest)
+}
+
+implement_test! {
+    alpha_blending_test, canvas_description |
+    DESTINATION_TRIANGLES[0],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[0],       FILL_SOURCE,      FILL_RULE, default_blending,
+    DESTINATION_TRIANGLES[1],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[1],       FILL_SOURCE,      FILL_RULE, destination_over,
+    DESTINATION_TRIANGLES[2],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[2],       FILL_SOURCE,      FILL_RULE, source_out,
+    DESTINATION_TRIANGLES[3],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[3],       FILL_SOURCE,      FILL_RULE, destination_out,
+    DESTINATION_TRIANGLES[4],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[4],       FILL_SOURCE,      FILL_RULE, source_in,
+    DESTINATION_TRIANGLES[5],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[5],       FILL_SOURCE,      FILL_RULE, destination_in,
+    DESTINATION_TRIANGLES[6],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[6],       FILL_SOURCE,      FILL_RULE, source_atop,
+    DESTINATION_TRIANGLES[7],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[7],       FILL_SOURCE,      FILL_RULE, destination_atop,
+    DESTINATION_TRIANGLES[8],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[8],       FILL_SOURCE,      FILL_RULE, xor,
+    DESTINATION_TRIANGLES[9],  FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[9],       FILL_SOURCE,      FILL_RULE, source,
+    DESTINATION_TRIANGLES[10], FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[10],      FILL_SOURCE,      FILL_RULE, destination,
+    DESTINATION_TRIANGLES[11], FILL_DESTINATION, FILL_RULE, default_blending,
+    SOURCE_TRIANGLES[11],      FILL_SOURCE,      FILL_RULE, additive
+}

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -1,5 +1,6 @@
 // This test draws a background on the whole canvas.
 
+use crate::common::default_blending;
 use verg::{
     canvas::{Canvas, CanvasDescription},
     color::{Color, FillRule, FillStyle},
@@ -41,4 +42,7 @@ static FILL_STYLE: FillStyle = FillStyle::Plain(Color::dark_slate_blue());
 
 const FILL_RULE: FillRule = FillRule::NonZero;
 
-implement_test! { basic_test, canvas_description | PATH, FILL_STYLE, FILL_RULE }
+implement_test! {
+    basic_test, canvas_description |
+    PATH, FILL_STYLE, FILL_RULE, default_blending
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,11 @@
 use sha2::{Digest, Sha256};
+use verg::color::Color;
+use verg::renderer::blend_func;
 
 // We allow dead code because clippy gives a false positive.
 // The constant is used in `implement_test!`.
 #[allow(dead_code)]
-pub const REFERENCE_HASHES: [(&str, &str); 5] = [
+pub const REFERENCE_HASHES: [(&str, &str); 6] = [
     (
         "basic_test",
         "95AEB28CB13578C558F745AD4DFCE5DF3BCAD3E11C0C9F15077ED3144C6D4D98",
@@ -24,6 +26,10 @@ pub const REFERENCE_HASHES: [(&str, &str); 5] = [
         "triangle_test",
         "765A7406D707AF35C371B3505B0688C51FB11B42BBB5B46233EAA445A2F28675",
     ),
+    (
+        "alpha_blending_test",
+        "70219E61B2E80A622F1288FCEA6F8E93F38213F6EAE3207637974B844505FC83",
+    ),
 ];
 
 pub fn get_hash_for_color_buffer(buffer: &[u8]) -> String {
@@ -32,13 +38,20 @@ pub fn get_hash_for_color_buffer(buffer: &[u8]) -> String {
     format!("{:X}", hasher.finalize())
 }
 
+// Another false positive, this function is used in a lot of tests.
+#[allow(dead_code)]
+pub fn default_blending(src: &Color, dest: &Color) -> Color {
+    blend_func::source_over(src, dest)
+}
+
 #[macro_export]
 macro_rules! implement_test {
-    ( $($name:ident, $canvas:ident)? | $($path:expr, $fill_style:expr, $fill_rule:expr),* ) => {
+    ( $($name:ident, $canvas:ident)? | $($path:expr, $fill_style:expr, $fill_rule:expr, $blend:ident),* ) => {
         #[test]
         fn $($name)?() {
             let mut canvas = Canvas::new($($canvas)?());
             $(
+                canvas.set_blending_function($blend);
                 canvas.draw_shape(&($path), $fill_style, $fill_rule);
             )*
 

--- a/tests/even_odd_fill_test.rs
+++ b/tests/even_odd_fill_test.rs
@@ -1,5 +1,6 @@
 // This tests draws a triangle inside a square using the even-odd fill rule.
 
+use crate::common::default_blending;
 use verg::{
     canvas::{Canvas, CanvasDescription},
     color::{Color, FillRule, FillStyle},
@@ -45,4 +46,7 @@ const FILL_STYLE: FillStyle = FillStyle::Plain(Color::white());
 
 const FILL_RULE: FillRule = FillRule::EvenOdd;
 
-implement_test! { even_odd_fill_test, canvas_description | PATH, FILL_STYLE, FILL_RULE }
+implement_test! {
+    even_odd_fill_test, canvas_description |
+    PATH, FILL_STYLE, FILL_RULE, default_blending
+}

--- a/tests/line_test.rs
+++ b/tests/line_test.rs
@@ -1,5 +1,6 @@
 // This test draws some open paths using only lines.
 
+use crate::common::default_blending;
 use verg::{
     canvas::{Canvas, CanvasDescription},
     color::{Color, FillRule, FillStyle},
@@ -53,10 +54,10 @@ const FILL_RULE: FillRule = FillRule::NonZero;
 
 implement_test! {
     line_test, canvas_description |
-    LINES[0], FILL_STYLE, FILL_RULE,
-    LINES[1], FILL_STYLE, FILL_RULE,
-    LINES[2], FILL_STYLE, FILL_RULE,
-    LINES[3], FILL_STYLE, FILL_RULE,
-    LINES[4], FILL_STYLE, FILL_RULE,
-    LINES[5], FILL_STYLE, FILL_RULE
+    LINES[0], FILL_STYLE, FILL_RULE, default_blending,
+    LINES[1], FILL_STYLE, FILL_RULE, default_blending,
+    LINES[2], FILL_STYLE, FILL_RULE, default_blending,
+    LINES[3], FILL_STYLE, FILL_RULE, default_blending,
+    LINES[4], FILL_STYLE, FILL_RULE, default_blending,
+    LINES[5], FILL_STYLE, FILL_RULE, default_blending
 }

--- a/tests/rect_test.rs
+++ b/tests/rect_test.rs
@@ -1,5 +1,6 @@
 // This test draws a rectangle that's not filled inside.
 
+use crate::common::default_blending;
 use verg::canvas::{Canvas, CanvasDescription};
 use verg::color::{Color, FillRule, FillStyle};
 use verg::geometry::PathOps;
@@ -43,4 +44,7 @@ const FILL_STYLE: FillStyle = FillStyle::Plain(Color::white());
 
 const FILL_RULE: FillRule = FillRule::NonZero;
 
-implement_test! { rect_test, canvas_description | PATH, FILL_STYLE, FILL_RULE }
+implement_test! {
+    rect_test, canvas_description |
+    PATH, FILL_STYLE, FILL_RULE, default_blending
+}

--- a/tests/triangle_test.rs
+++ b/tests/triangle_test.rs
@@ -1,5 +1,6 @@
 // This test draws a bunch of triangles of different sizes, colors and shapes.
 
+use crate::common::default_blending;
 use verg::canvas::{Canvas, CanvasDescription};
 use verg::color::{Color, FillRule, FillStyle};
 use verg::geometry::PathOps;
@@ -102,12 +103,12 @@ const FILL_RULE: FillRule = FillRule::NonZero;
 
 implement_test! {
     triangle_test, canvas_description |
-    BIG_TRIANGLE,               FILL_WHITE,    FILL_RULE,
-    SMALL_WHITE_TRIANGLE,       FILL_WHITE,    FILL_RULE,
-    RED_TRIANGLES,              FILL_RED,      FILL_RULE,
-    BLUE_RECT,                  FILL_BLUE,     FILL_RULE,
-    IMPERFECT_RECT_PART1,       FILL_CYAN,     FILL_RULE,
-    IMPERFECT_RECT_PART2,       FILL_CYAN,     FILL_RULE,
-    DIAMOND,                    FILL_DIAMOND,  FILL_RULE,
-    SMALL_PURPLE_TRIANGLE,      FILL_PURPLE,   FILL_RULE
+    BIG_TRIANGLE,               FILL_WHITE,    FILL_RULE, default_blending,
+    SMALL_WHITE_TRIANGLE,       FILL_WHITE,    FILL_RULE, default_blending,
+    RED_TRIANGLES,              FILL_RED,      FILL_RULE, default_blending,
+    BLUE_RECT,                  FILL_BLUE,     FILL_RULE, default_blending,
+    IMPERFECT_RECT_PART1,       FILL_CYAN,     FILL_RULE, default_blending,
+    IMPERFECT_RECT_PART2,       FILL_CYAN,     FILL_RULE, default_blending,
+    DIAMOND,                    FILL_DIAMOND,  FILL_RULE, default_blending,
+    SMALL_PURPLE_TRIANGLE,      FILL_PURPLE,   FILL_RULE, default_blending
 }


### PR DESCRIPTION
Allow the user to give an arbitrary blending function to the canvas and implement the Porter-Duff operators.